### PR TITLE
Add more specific input and output

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@ Built by Christopher Moravec, Bethany Soule, and Daniel Reeves.
 Based on an Android app that Soule and Reeves published in 2010 (!) and that's 
 technically still in Google's app store but doesn't work on modern phones.
 Thanks to Dave Pennock who invented the restaurant bill-splitting algorithm.
+UI enhancements by Daniel Zwell.
 See 
 <a href="http://messymatters.com/expectorant" title="Stochastic, Nerdtastic Restaurant Bill Splitting on Danny and Sharad's old Messy Matters blog">the original blog post</a>
 for more.

--- a/index.html
+++ b/index.html
@@ -38,6 +38,18 @@
 <h1>Expectorant</h1>
 
 <div>
+  <h2>Exact Change: Repayment with Cash</h2>
+  <input type="number" id="expr-repay-owe" type="text" size="80" placeholder="You owe this much"/>
+  <input type="number" id="expr-repay-note1" type="text" size="80" placeholder="You have this note"/>
+  <input type="number" id="expr-repay-note2" type="text" size="80" placeholder="Optional: you also have this note"/>
+  <br>
+  <span id="prob-wrap">p=<span id="prob">0%</span></span>
+  <span id="counter-wrap">n=<span id="counter">0</span></span>
+</div>
+<br>
+
+<div>
+  <h2>All payment types</h2>
   <input id="expr" type="text" size="80"
          placeholder="Expression that evaluates to a probability"/>
   <br>

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
 <br>
 <b><center id="theanswer">&nbsp;</center></b>
 </div>
+<input type="checkbox" id="mute" name="mute"/><label for="mute">Mute</label><br>
 
   
 <details open id="instructions">

--- a/main.js
+++ b/main.js
@@ -93,20 +93,27 @@ function expectorize(spob) {
   spingo(spob, windex)
 }
   
-document.addEventListener('DOMContentLoaded', () => { // -------- document-ready
+function expectorizeRepay(spob) {
+  expectorize(spob)
+}
 
+document.addEventListener('DOMContentLoaded', () => { // -------- document-ready
 $('expr').focus() // this can be annoying when developing cuz it steals focus
 $('prob').innerHTML = INITPROB
 $('vittle').innerHTML = VITTLES[vindex]
 const spob = spinit(document.querySelector('#spinneroo'), genslots(INITPROB))
 spindraw(spob)
-  
-// Update the slots and redraw the spinner on every keystroke in the input field
-$('expr').addEventListener('input', e => {
-  const p = probabilify(e.target.value)
+
+function redrawSlots() {
+  const p = probabilify($('expr').value)
   $('prob').innerHTML = roundp(p, 8) // max 17; make it big for debugging
   spob.slots = genslots(p)
   spindraw(spob)
+}
+
+// Update the slots and redraw the spinner on every keystroke in the input field
+$('expr').addEventListener('input', e => {
+  redrawSlots()
 })
 
 $('expectorize').addEventListener('click', e => expectorize(spob))
@@ -116,6 +123,41 @@ $('expr').addEventListener('keyup', e => {
 })
 $('expr').addEventListener('keydown', e => {
   if (e.metaKey && e.key === "Enter") expectorize(spob)
+})
+
+const fieldNames = ['expr-repay-note1', 'expr-repay-note2', 'expr-repay-owe']
+fieldNames.forEach((fieldName) => {
+  // Make any input update the main input field and redraw the spinner
+  $(fieldName).addEventListener('input', e => {
+    const notes = []
+    if ($('expr-repay-note1').value) {
+      notes.push($('expr-repay-note1').value)
+    }
+    if ($('expr-repay-note2').value) {
+      notes.push($('expr-repay-note2').value)
+    }
+    if (notes.length == 2) {
+      if (parseInt(notes[0]) > parseInt(notes[1])) {
+        var swap = notes[0]
+        notes[0] = notes[1]
+        notes[1] = swap
+      }
+
+      // 8.27@5,20 means I owe 8.27 but have a $5 note and a $20 note
+      $('expr').value = `${$('expr-repay-owe').value}@${notes[0]},${notes[1]}`
+    } else {
+      // 7/20 means I owe 7 but have a $20 note
+      $('expr').value = `${$('expr-repay-owe').value}/${notes[0]}`
+    }
+
+    redrawSlots()
+  })
+  $(fieldName).addEventListener('keyup', e => {
+    if (e.key==="Enter") expectorizeRepay(spob)
+  })
+  $(fieldName).addEventListener('keydown', e => {
+    if (e.metaKey && e.key === "Enter") expectorizeRepay(spob)
+  })
 })
 
 }) // ------------------------------------------------------- end document-ready

--- a/main.js
+++ b/main.js
@@ -168,6 +168,11 @@ fieldNames.forEach((fieldName) => {
   })
 })
 
+$('audiotag1').muted = $('mute').checked
+$('mute').addEventListener('change', e => {
+  $('audiotag1').muted = e.target.checked
+})
+
 }) // ------------------------------------------------------- end document-ready
 
 function shuffle(l) {

--- a/main.js
+++ b/main.js
@@ -104,16 +104,22 @@ $('vittle').innerHTML = VITTLES[vindex]
 const spob = spinit(document.querySelector('#spinneroo'), genslots(INITPROB))
 spindraw(spob)
 
-function redrawSlots() {
+function redrawSlots(scenario) {
   const p = probabilify($('expr').value)
   $('prob').innerHTML = roundp(p, 8) // max 17; make it big for debugging
-  spob.slots = genslots(p)
+  spob.slots = genslots(p, scenario)
   spindraw(spob)
 }
 
 // Update the slots and redraw the spinner on every keystroke in the input field
 $('expr').addEventListener('input', e => {
-  redrawSlots()
+  // Consider this a two-bill repayment choice only if it's syntactically specified:
+  if (e.target.value.includes('@')) {
+    var scenario = Scenario.RepayTwoNotes
+  } else if (e.target.value.includes(':')) {
+    scenario = Scenario.SplitBill
+  }
+  redrawSlots(scenario)
 })
 
 $('expectorize').addEventListener('click', e => expectorize(spob))
@@ -145,12 +151,14 @@ fieldNames.forEach((fieldName) => {
 
       // 8.27@5,20 means I owe 8.27 but have a $5 note and a $20 note
       $('expr').value = `${$('expr-repay-owe').value}@${notes[0]},${notes[1]}`
+
+      redrawSlots(Scenario.RepayTwoNotes)
     } else {
       // 7/20 means I owe 7 but have a $20 note
       $('expr').value = `${$('expr-repay-owe').value}/${notes[0]}`
-    }
 
-    redrawSlots()
+      redrawSlots(Scenario.RepayOneNote)
+    }
   })
   $(fieldName).addEventListener('keyup', e => {
     if (e.key==="Enter") expectorizeRepay(spob)

--- a/spinner.js
+++ b/spinner.js
@@ -197,11 +197,18 @@ function spinit(div, slots) { return {
   dcur:   0,                        // current distance in degrees it has spun
 }}
 
+const Scenario = {
+  General: 0,
+  RepayOneNote: 1,
+  RepayTwoNotes: 2,
+  SplitBill: 3,
+}
+
 // Generate a list of slots from a probability (just need one probability for
 // two slots) or a list of probabilities that sum to one.
 // For the case of 2 slots in Expectorant, the first slot is for
 // yes/pay/high/green and the second is for no/free/low/red.
-function genslots(p) {
+function genslots(p, scenario) {
   ASSERT(!Array.isArray(p), "More than 2 slots not supported yet")
   if (isNaN(p) || p < 0 || p > 1) {
     const d1 = "nothing"
@@ -210,9 +217,21 @@ function genslots(p) {
       { label: "🍌", prob: 1, kyoom: 1, color: 'black', desc: d1 },
       { label: "🍒", prob: 0, kyoom: 1, color: 'taupe', desc: d2 }, ]
   } else {
-    const d1 = "YES / PAY / HIGH"
-    const d2 = "NO / FREE / LOW"
-    return [ 
+    if (scenario == Scenario.RepayOneNote) {
+      var d1 = "YES / PAY"
+      var d2 = "NO / FREE"
+    } else if (scenario == Scenario.RepayTwoNotes) {
+      d1 = "PAY HIGH"
+      d2 = "PAY LOW"
+    } else if (scenario == Scenario.SplitBill) {
+      d1 = "PAY"
+      d2 = "FREE"
+    } else {
+      d1 = "YES / PAY / HIGH"
+      d2 = "NO / FREE / LOW"
+    }
+
+    return [
       { label: percentify(p),   prob: p,   kyoom: p, color: YAYCOLOR, desc: d1},
       { label: percentify(1-p), prob: 1-p, kyoom: 1, color: NAYCOLOR, desc: d2},
     ]


### PR DESCRIPTION
This change adds dedicated input fields for the case of needing to probabilistically repay an amount with one or two exact notes.

This change also changes the output to be simpler if the new input fields are used, or if '@' or ':' is detected in the input, because the operation is known in that case. (For instance you don't need to output "FREE / LOW" if you know it's a choice between paying low or paying high. "PAY LOW" is clearer.) This fixes #13

I also added a "mute" checkbox because although the audio is cute, I don't see how you develop with it playing at every test! This fixes #11