### PR TITLE
Put the first inputs all on one line in Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
 
 <div>
   <h2>Exact Change: Repayment with Cash</h2>
-  <input type="number" id="expr-repay-owe" type="text" size="80" placeholder="You owe this much"/>
-  <input type="number" id="expr-repay-note1" type="text" size="80" placeholder="You have this note"/>
-  <input type="number" id="expr-repay-note2" type="text" size="80" placeholder="Optional: you also have this note"/>
+  <input type="number" class="exact-change" id="expr-repay-owe" type="text" size="80" placeholder="You owe this much"/>
+  <input type="number" class="exact-change" id="expr-repay-note1" type="text" size="80" placeholder="You have this note"/>
+  <input type="number" class="exact-change" id="expr-repay-note2" type="text" size="80" placeholder="Optional: you also have this note"/>
 </div>
 <br>
 

--- a/style.css
+++ b/style.css
@@ -117,12 +117,15 @@ button:active .button-text {
 /* .spin */
 #spinneroo { transform-origin: 50% 50%; }
 
-input { 
+input {
   height: 24px;
   padding: 8px;
   font-size: 16pt;
-  width:95%;
-  max-width: 390px; /* 390px is just enough for the placeholder text */
+  width: 390px; /* 390px is just enough for the placeholder text */
+}
+
+input.exact-change {
+  width: 335px;
 }
 
 /* Bee doesn't like the "p=0.123" being gray. Dreev kinda does. The idea was to


### PR DESCRIPTION
This change doesn't specifically address the centering issue you mentioned, but it makes the page look better in Chrome IMO. (I can only reproduce your issue in the Firefox responsive design mode, but couldn't fix it.)

Do you want the original input to have 95% width? I'd hate to break something, but it looked like a rule that was not having an effect. (Again, I'm not a front-end developer.)